### PR TITLE
[AP-762][Feat] Support transformation of fields in json-type columns

### DIFF
--- a/sample_config.json
+++ b/sample_config.json
@@ -1,0 +1,25 @@
+
+{
+  "transformations": [
+    {
+      "field_id": "password_hash",
+      "tap_stream_name": "stream-id-sent-by-the-tap",
+      "type": "MASK-HIDDEN"
+    },
+    {
+      "field_id": "salt",
+      "tap_stream_name": "stream-id-sent-by-the-tap",
+      "type": "HASH"
+    },
+    {
+      "field_id": "value",
+      "tap_stream_name": "stream-id-sent-by-the-tap",
+      "type": "SET-NULL",
+      "when": [
+        {"column": "string_column_1", "equals": "Property" },
+        {"column": "numeric_column", "equals": 200 },
+        {"column": "string_column_2", "regex_match": "sensitive.*PII" }
+      ]
+    }
+  ]
+}

--- a/sample_config.json
+++ b/sample_config.json
@@ -20,6 +20,12 @@
         {"column": "numeric_column", "equals": 200 },
         {"column": "string_column_2", "regex_match": "sensitive.*PII" }
       ]
+    },
+    {
+      "field_id": "metadata",
+      "tap_stream_name": "stream-id-sent-by-the-tap",
+      "type": "MASK-HIDDEN",
+      "field_paths": ["user/address", "user/zip_code"]
     }
   ]
 }

--- a/setup.py
+++ b/setup.py
@@ -23,17 +23,18 @@ setup(name='pipelinewise-transform-field',
       py_modules=['transform_field'],
       install_requires=[
           'pipelinewise-singer-python==1.*',
+          'dpath==2.0.*',
       ],
       extras_require={
-        'test': [
-            'pytest==6.2.*',
-            'pytest-cov==2.12.*',
-            'pylint==2.7.*',
-        ]
+          'test': [
+              'pytest==6.2.*',
+              'pytest-cov==2.12.*',
+              'pylint==2.7.*',
+          ]
       },
       entry_points='''
           [console_scripts]
           transform-field=transform_field:main
       ''',
       packages=['transform_field']
-)
+      )

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -46,10 +46,10 @@ class TestTransformField(unittest.TestCase):
         self.assertDictEqual(instance.stream_meta, {})
         self.assertDictEqual(instance.trans_meta, {
             'stream_1': [
-                TransMeta('column_1', 'SET-NULL', None),
-                TransMeta('column_2', 'HASH', []),
+                TransMeta('column_1', 'SET-NULL', None, None),
+                TransMeta('column_2', 'HASH', [], None),
             ],
-            'stream_2': [TransMeta('column_1', 'MASK-DATE', None)],
+            'stream_2': [TransMeta('column_1', 'MASK-DATE', None, None)],
         })
 
     def test_validate_without_catalog_fails(self):

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -137,3 +137,77 @@ class TestTransform(unittest.TestCase):
             # Expected output:
             "123456789"
         )
+
+    def test_transform_field_in_json_col(self):
+        """Test transformation of a field in a json column with no conditions"""
+
+        expected_value = {'id': 1, 'info': {'last_name': 'hidden', 'first_name': 'John'}}
+
+        return_value = transform.do_transform(
+            # Record:
+            {
+                "col_1": "com.transferwise.fx.user.User",
+                "col_2": "passwordHash",
+                "col_3": "lkj",
+                'col_4': {'id': 1, 'info': {'last_name': 'Smith', 'first_name': 'John'}}
+            },
+            # Column to transform:
+            "col_4",
+            # Transform method:
+            "MASK-HIDDEN",
+            # Conditions when to transform:
+            None,
+            ['info/last_name']
+        )
+
+        self.assertEqual(expected_value, return_value)
+
+    def test_transform_field_in_json_col_with_conditions(self):
+        """Test transformation of a field in a json column with conditions"""
+
+        expected_value = {'id': 1, 'info': {'last_name': 'hidden', 'first_name': 'John'}}
+
+        return_value = transform.do_transform(
+            # Record:
+            {
+                "col_1": "com.transferwise.fx.user.User",
+                "col_2": "passwordHash",
+                "col_3": "lkj",
+                'col_4': {'id': 1, 'info': {'last_name': 'Smith', 'first_name': 'John'}}
+            },
+            # Column to transform:
+            "col_4",
+            # Transform method:
+            "MASK-HIDDEN",
+            # Conditions when to transform:
+            [
+                {'column': 'col_2', 'equals': "passwordHash"},
+            ],
+            ['info/last_name']
+        )
+
+        self.assertEqual(expected_value, return_value)
+
+    def test_transform_fields_in_json_col(self):
+        """Test transformation of multiple fields in a json column with no conditions"""
+
+        expected_value = {'id': 1, 'info': {'last_name': 'hidden', 'first_name': 'hidden', 'age': 25}}
+
+        return_value = transform.do_transform(
+            # Record:
+            {
+                "col_1": "com.transferwise.fx.user.User",
+                "col_2": "passwordHash",
+                "col_3": "lkj",
+                'col_4': {'id': 1, 'info': {'last_name': 'Smith', 'first_name': 'John', 'age': 25}}
+            },
+            # Column to transform:
+            "col_4",
+            # Transform method:
+            "MASK-HIDDEN",
+            # Conditions when to transform:
+            None,
+            ['info/last_name', 'info/first_name']
+        )
+
+        self.assertEqual(expected_value, return_value)

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -186,7 +186,7 @@ class TestTransform(unittest.TestCase):
             ['info/last_name']
         )
 
-        self.assertEqual(expected_value, return_value)
+        self.assertDictEqual(expected_value, return_value)
 
     def test_transform_fields_in_json_col(self):
         """Test transformation of multiple fields in a json column with no conditions"""
@@ -210,4 +210,4 @@ class TestTransform(unittest.TestCase):
             ['info/last_name', 'info/first_name']
         )
 
-        self.assertEqual(expected_value, return_value)
+        self.assertDictEqual(expected_value, return_value)

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -160,7 +160,7 @@ class TestTransform(unittest.TestCase):
             ['info/last_name']
         )
 
-        self.assertEqual(expected_value, return_value)
+        self.assertDictEqual(expected_value, return_value)
 
     def test_transform_field_in_json_col_with_conditions(self):
         """Test transformation of a field in a json column with conditions"""

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -39,7 +39,7 @@ class TestTransform(unittest.TestCase):
             "2019-01-01T13:34:11"
         )
 
-        # Mask date should keep the time elements
+        # Mask date should keep the time elements, date is invalid
         self.assertEqual(
             transform.do_transform({"col_1": "2019-05-21T13:34:99"}, "col_1", "MASK-DATE"),
             "2019-05-21T13:34:99"

--- a/transform_field/__init__.py
+++ b/transform_field/__init__.py
@@ -271,8 +271,11 @@ class TransformField:
                 field_type = stream_schema['properties'][field_id].get('type')
                 field_format = stream_schema['properties'][field_id].get('format')
 
-            # If the value we want to transform is a field in a JSON property then no need to enforce rules below for now
-            if ("object" in field_type or "array" in field_type) and transformation.field_paths:
+            # If the value we want to transform is a field in a JSON property
+            # then no need to enforce rules below for now
+            if field_type and \
+                    ("object" in field_type or "array" in field_type) and \
+                    transformation.field_paths is not None:
                 continue
 
             if trans_type in (TransformationTypes.HASH.value, TransformationTypes.MASK_HIDDEN.value) or \

--- a/transform_field/__init__.py
+++ b/transform_field/__init__.py
@@ -10,8 +10,8 @@ from decimal import Decimal
 from jsonschema import FormatChecker, Draft7Validator
 from singer import Catalog, Schema
 
-import transform_field.transform as transform
-import transform_field.utils as utils
+from transform_field import transform
+from transform_field import utils
 from transform_field.timings import Timings
 
 from transform_field.errors import CatalogRequiredException, StreamNotFoundException, InvalidTransformationException, \

--- a/transform_field/__init__.py
+++ b/transform_field/__init__.py
@@ -11,10 +11,11 @@ from enum import Enum, unique
 from collections import namedtuple
 from decimal import Decimal
 from jsonschema import FormatChecker, Draft7Validator
-from singer import Catalog, SchemaMessage, Schema
+from singer import Catalog, Schema
 
 import transform_field.transform as transform
 import transform_field.utils as utils
+
 from transform_field.errors import CatalogRequiredException, StreamNotFoundException, InvalidTransformationException, \
     UnsupportedTransformationTypeException, NoStreamSchemaException
 
@@ -28,7 +29,7 @@ DEFAULT_BATCH_DELAY_SECONDS = 300.0
 VALIDATE_RECORDS = False
 
 StreamMeta = namedtuple('StreamMeta', ['schema', 'key_properties', 'bookmark_properties'])
-TransMeta = namedtuple('TransMeta', ['field_id', 'type', 'when'])
+TransMeta = namedtuple('TransMeta', ['field_id', 'type', 'when', 'field_paths'])
 
 REQUIRED_CONFIG_KEYS = [
     "transformations"
@@ -96,7 +97,8 @@ class TransformField:
             self.trans_meta[stream].append(TransMeta(
                 trans["field_id"],
                 trans["type"],
-                trans.get('when')
+                trans.get('when'),
+                trans.get('field_paths')
             ))
 
     # pylint: disable=too-many-nested-blocks,too-many-branches
@@ -124,7 +126,9 @@ class TransformField:
                     for trans in trans_meta:
 
                         if trans.field_id in message.record:
-                            transformed = transform.do_transform(message.record, trans.field_id, trans.type, trans.when)
+                            transformed = transform.do_transform(
+                                message.record, trans.field_id, trans.type, trans.when, trans.field_paths
+                            )
                             message.record[trans.field_id] = transformed
 
                     if VALIDATE_RECORDS:
@@ -269,6 +273,11 @@ class TransformField:
             else:
                 field_type = stream_schema['properties'][field_id].get('type')
                 field_format = stream_schema['properties'][field_id].get('format')
+
+            # if the value we want to transform is a field in a JSON property then no need to enforce rules below
+            if ("object" in field_type or "array" in field_type) and transformation.field_paths:
+                # todo write better handling maybe
+                continue
 
             if trans_type in (TransformationTypes.HASH.value, TransformationTypes.MASK_HIDDEN.value) or \
                     trans_type.startswith(TransformationTypes.HASH_SKIP_FIRST.value) or \

--- a/transform_field/__init__.py
+++ b/transform_field/__init__.py
@@ -1,12 +1,9 @@
-#!/usr/bin/env python3
-
 import io
 import sys
 import time
-from typing import Union, Dict
-
 import singer
 
+from typing import Union, Dict
 from enum import Enum, unique
 from collections import namedtuple
 from decimal import Decimal
@@ -15,11 +12,11 @@ from singer import Catalog, Schema
 
 import transform_field.transform as transform
 import transform_field.utils as utils
+from transform_field.timings import Timings
 
 from transform_field.errors import CatalogRequiredException, StreamNotFoundException, InvalidTransformationException, \
     UnsupportedTransformationTypeException, NoStreamSchemaException
 
-from transform_field.timings import Timings
 
 LOGGER = singer.get_logger('transform_field')
 TIMINGS = Timings(LOGGER)
@@ -274,9 +271,8 @@ class TransformField:
                 field_type = stream_schema['properties'][field_id].get('type')
                 field_format = stream_schema['properties'][field_id].get('format')
 
-            # if the value we want to transform is a field in a JSON property then no need to enforce rules below
+            # If the value we want to transform is a field in a JSON property then no need to enforce rules below for now
             if ("object" in field_type or "array" in field_type) and transformation.field_paths:
-                # todo write better handling maybe
                 continue
 
             if trans_type in (TransformationTypes.HASH.value, TransformationTypes.MASK_HIDDEN.value) or \

--- a/transform_field/transform.py
+++ b/transform_field/transform.py
@@ -1,7 +1,12 @@
 import hashlib
 import re
 
+from typing import Dict, Any, Optional, List
+from dpath.util import get as get_xpath, set as set_xpath
+from singer import get_logger
 from dateutil import parser
+
+LOGGER = get_logger('transform_field')
 
 
 def is_transform_required(record, when):
@@ -55,11 +60,9 @@ def do_transform(record: Dict,
     Optionally can set conditional criteria based on other
     values of the record"""
 
-    return_value = None
+    return_value = value = record.get(field)
 
     try:
-        value = record.get(field)
-
         # Do transformation only if required
         if is_transform_required(record, when):
 

--- a/transform_field/transform.py
+++ b/transform_field/transform.py
@@ -45,53 +45,37 @@ def is_transform_required(record, when):
     return transform_required
 
 
-def do_transform(record, field, trans_type, when=None):
+def do_transform(record: Dict,
+                 field: str,
+                 trans_type: str,
+                 when: Optional[List[Dict]] = None,
+                 field_paths: Optional[List[str]] = None
+                 ) -> Any:
     """Transform a value by a certain transformation type.
     Optionally can set conditional criteria based on other
     values of the record"""
+
+    return_value = None
+
     try:
         value = record.get(field)
 
         # Do transformation only if required
         if is_transform_required(record, when):
 
-            # Transforms any input to NULL
-            if trans_type == "SET-NULL":
-                return_value = None
+            # transforming fields nested in value dictionary
+            if isinstance(value, dict) and field_paths:
+                for field_path in field_paths:
+                    try:
+                        field_val = get_xpath(value, field_path)
+                        set_xpath(value, field_path, _transform_value(field_val, trans_type))
+                    except KeyError:
+                        LOGGER.error('Field path %s does not exist', field_path)
 
-            # Transforms string input to hash
-            elif trans_type == "HASH":
-                return_value = hashlib.sha256(value.encode('utf-8')).hexdigest()
-
-            # Transforms string input to hash skipping first n characters, e.g. HASH-SKIP-FIRST-2
-            elif 'HASH-SKIP-FIRST' in trans_type:
-                return_value = value[:int(trans_type[-1])] + \
-                               hashlib.sha256(value.encode('utf-8')[int(trans_type[-1]):]).hexdigest()
-
-            # Transforms any date to stg
-            elif trans_type == "MASK-DATE":
-                return_value = parser.parse(value).replace(month=1, day=1).isoformat()
-
-            # Transforms any number to zero
-            elif trans_type == "MASK-NUMBER":
-                return_value = 0
-
-            # Transforms any value to "hidden"
-            elif trans_type == "MASK-HIDDEN":
-                return_value = 'hidden'
-
-            # Transforms string input to masked version skipping first and last n characters
-            # e.g. MASK-STRING-SKIP-ENDS-3
-            elif 'MASK-STRING-SKIP-ENDS' in trans_type:
-                skip_ends_n = int(trans_type[-1])
-                value_len = len(value)
-                return_value = '*'*value_len if value_len <= (2 * skip_ends_n) \
-                    else f'{value[:skip_ends_n]}{"*"*(value_len-(2*skip_ends_n))}{value[-skip_ends_n:]}'
-
-            # Return the original value if cannot find transformation type
-            # todo: is this the right behavior?
-            else:
                 return_value = value
+
+            else:
+                return_value = _transform_value(value, trans_type)
 
         # Return the original value if cannot find transformation type
         else:
@@ -101,4 +85,55 @@ def do_transform(record, field, trans_type, when=None):
 
     # Return the original value if cannot transform
     except Exception:
-        return value
+        return return_value
+
+
+def _transform_value(value: Any, trans_type: str) -> Any:
+    """
+    Applies the given transformation type to the given value
+    Args:
+        value: value to transform
+        trans_type: transformation type to apply
+
+    Returns:
+        transformed value
+    """
+    # Transforms any input to NULL
+    if trans_type == "SET-NULL":
+        return_value = None
+
+    # Transforms string input to hash
+    elif trans_type == "HASH":
+        return_value = hashlib.sha256(value.encode('utf-8')).hexdigest()
+
+    # Transforms string input to hash skipping first n characters, e.g. HASH-SKIP-FIRST-2
+    elif 'HASH-SKIP-FIRST' in trans_type:
+        return_value = value[:int(trans_type[-1])] + \
+                       hashlib.sha256(value.encode('utf-8')[int(trans_type[-1]):]).hexdigest()
+
+    # Transforms any date to stg
+    elif trans_type == "MASK-DATE":
+        return_value = parser.parse(value).replace(month=1, day=1).isoformat()
+
+    # Transforms any number to zero
+    elif trans_type == "MASK-NUMBER":
+        return_value = 0
+
+    # Transforms any value to "hidden"
+    elif trans_type == "MASK-HIDDEN":
+        return_value = 'hidden'
+
+    # Transforms string input to masked version skipping first and last n characters
+    # e.g. MASK-STRING-SKIP-ENDS-3
+    elif 'MASK-STRING-SKIP-ENDS' in trans_type:
+        skip_ends_n = int(trans_type[-1])
+        value_len = len(value)
+        return_value = '*' * value_len if value_len <= (2 * skip_ends_n) \
+            else f'{value[:skip_ends_n]}{"*" * (value_len - (2 * skip_ends_n))}{value[-skip_ends_n:]}'
+
+    # Return the original value if cannot find transformation type
+    # todo: is this the right behavior?
+    else:
+        return_value = value
+
+    return return_value


### PR DESCRIPTION
## Context

Currently, we can apply transformations on various columns of simple types such as number, strings, dates ...etc. However, we don't have the same feature to transform certain fields nested in a json-type column.

This PR is add this capability, it makes use of XPaths as a way to point to one or multiple fields in a JSON object and transforming it. 

### Example

Assume you have a stream named `my_cool_db-users` which has an field of type object which contains metadata about users. 
The tap produces singer records such as these:
```
{
            "id": 100,
            "first_name": "John",
            "last_name": "Smith",
            "metadata": {"user": {"address": "Vereeni 23" , "zip_code": "362294"}, "browser": "Firefox", "platform": "android"}
        }
```

Given that this streams contains sensitive data that need to be transformed, you now can transform the specified fields inside the `metadata` object like so:

```
"transformations": [
   {
        "field_id": "metadata",
        "tap_stream_name": "my_cool_db-users",
        "type": "MASK-HIDDEN",
        "field_paths": ["user/address", "user/zip_code"]
   }
]
```



