### PR TITLE
Chore make transform work with json string data

### DIFF
--- a/transform_field/transform.py
+++ b/transform_field/transform.py
@@ -1,5 +1,6 @@
 import hashlib
 import re
+import json
 
 from typing import Dict, Any, Optional, List
 from dpath.util import get as get_xpath, set as set_xpath
@@ -42,7 +43,7 @@ def is_transform_required(record: Dict, when: Optional[List[Dict]]) -> bool:
                 # transformation so breaking prematurely
                 transform_required = False
 
-                LOGGER.debug('field "%s" doesn\'t exists in the value of column "%s", '
+                LOGGER.debug('field "%s" doesn\'t exist in the value of column "%s", '
                              'so transformation is not required.', field_path_to_match, column_to_match)
                 break
 
@@ -118,6 +119,8 @@ def do_transform(record: Dict,
     try:
         # Do transformation only if required
         if is_transform_required(record, when):
+            # Convert value to a JSON object (Dict)
+            value = json.loads(value)
 
             # transforming fields nested in value dictionary
             if isinstance(value, dict) and field_paths:

--- a/transform_field/transform.py
+++ b/transform_field/transform.py
@@ -119,6 +119,7 @@ def do_transform(record: Dict,
     try:
         # Do transformation only if required
         if is_transform_required(record, when):
+
             # Convert value to a JSON object (Dict)
             value = json.loads(value)
 
@@ -131,7 +132,7 @@ def do_transform(record: Dict,
                     except KeyError:
                         LOGGER.error('Field path %s does not exist', field_path)
 
-                return_value = value
+                return_value = json.dumps(value)
 
             else:
                 return_value = _transform_value(value, trans_type)

--- a/transform_field/transform.py
+++ b/transform_field/transform.py
@@ -132,7 +132,7 @@ def do_transform(record: Dict,
                     except KeyError:
                         LOGGER.error('Field path %s does not exist', field_path)
 
-                return_value = json.dumps(value)
+                return_value = value = json.dumps(value)
 
             else:
                 return_value = _transform_value(value, trans_type)

--- a/transform_field/transform.py
+++ b/transform_field/transform.py
@@ -121,6 +121,7 @@ def do_transform(record: Dict,
         if is_transform_required(record, when):
 
             # Convert value to a JSON object (Dict)
+            LOGGER.debug('Convert value in field %s to Dict ?', field)
             value = json.loads(value)
 
             # transforming fields nested in value dictionary
@@ -133,6 +134,7 @@ def do_transform(record: Dict,
                         LOGGER.error('Field path %s does not exist', field_path)
 
                 return_value = value = json.dumps(value)
+                LOGGER.debug('Convert value in field %s to String after tranforms ?', field)
 
             else:
                 return_value = _transform_value(value, trans_type)


### PR DESCRIPTION
## Problem

_JSON data is encoded as strings in some fields._

When this is the case the string JSON will need conversion to a `Dict` using `json.loads`

## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._


## Types of changes

What types of changes does your code introduce to pipelinewise-transform-field?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/transferwise/pipelinewise/blob/master/CONTRIBUTING.md) doc.
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
